### PR TITLE
Remove 'exam' parameter from the ResponseNode.example method

### DIFF
--- a/lib/swagger/blocks.rb
+++ b/lib/swagger/blocks.rb
@@ -613,10 +613,9 @@ module Swagger
         self.data[:headers][head] = Swagger::Blocks::HeaderNode.call(version: version, inline_keys: inline_keys, &block)
       end
 
-      def example(exam, inline_keys = nil, &block)
+      def example(inline_keys = nil, &block)
         # TODO validate 'exam' is as per spec
-        self.data[:examples] ||= {}
-        self.data[:examples][exam] = Swagger::Blocks::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
+        self.data[:examples] = Swagger::Blocks::ExampleNode.call(version: version, inline_keys: inline_keys, &block)
       end
     end
 


### PR DESCRIPTION
Having the exam parameter added another level of hierarchy for example definitions which was unnecessary.  This made it impossible to give a response example that returned an array without wrapping it within a hash object. Index calls need to return an array. Now things like the below will be possible

swagger_path '/items' do
  operation :get do
    response 200 do
      key :description, 'OK'
      example do
        key :"application/json", [item1_json, item2_json]
     end
  end
end

instead of

swagger_path '/items' do
  operation :get do
    response 200 do
      key :description, 'OK'
      example **:"some_unnecessary_hash"** do
        key :"application/json", [item1_json, item2_json]
     end
  end
end
